### PR TITLE
change from arccoord to arcoordmid

### DIFF
--- a/src/OscillatingHeatPipe.jl
+++ b/src/OscillatingHeatPipe.jl
@@ -14,7 +14,7 @@ using Reexport
 using OrdinaryDiffEqLowOrderRK
 
 @reexport using ComputationalHeatTransfer
-import RigidBodyTools: arccoord,arclength
+import RigidBodyTools: arccoordmid,arclength
 
 export expfileDict,INCHES, GRAVITY
 

--- a/src/utils/Postprocessing.jl
+++ b/src/utils/Postprocessing.jl
@@ -264,8 +264,8 @@ function oneDtwoDtransform(ξ,sr::SimulationResult)
 
     @unpack x,y = ohp.transform(ohp.shape)
 
-    interp_linear_x = LinearInterpolation(arccoord(ohp.shape), x,extrapolation_bc = Line());
-    interp_linear_y = LinearInterpolation(arccoord(ohp.shape), y,extrapolation_bc = Line());
+    interp_linear_x = LinearInterpolation(arccoordmid(ohp.shape), x,extrapolation_bc = Line());
+    interp_linear_y = LinearInterpolation(arccoordmid(ohp.shape), y,extrapolation_bc = Line());
 
     x2D = interp_linear_x[ξ]
     y2D = interp_linear_y[ξ];

--- a/src/utils/Preprocessing.jl
+++ b/src/utils/Preprocessing.jl
@@ -22,7 +22,7 @@ function onesideXp(ohp,tube::Tube,line)
 
     ls_label = xor.(largeorsmall, [largeorsmall[2:end];largeorsmall[1]])
     X0array_label = findall(!iszero,ls_label)
-    X0array = ohp.arccoord[X0array_label]
+    X0array = ohp.arccoordmid[X0array_label]
 
     X0 = map(tuple,X0array[1:2:end], X0array[2:2:end])
 
@@ -197,7 +197,7 @@ function initialize_ohpsys(sys::ILMSystem,p_fluid,power;closedornot=DEFAULT_CLOS
     Xstation_time = zeros(nucleatenum);
     boil_type = "wall T"
     boil_interval = boil_waiting_time
-    Xwallarray,θwallarray,curvwallarray = constructwallXθarray(arccoord(ohp.shape),Tref,curvature(ohp.shape));
+    Xwallarray,θwallarray,curvwallarray = constructwallXθarray(arccoordmid(ohp.shape),Tref,curvature(ohp.shape));
     wall = Wall(boil_interval=boil_interval,fluid_type=fluid_type,boil_type=boil_type,power=power,L_newbubble=L_newbubble,Xstations=Xstations,boiltime_stations=Xstation_time,Xarray=Xwallarray,θarray=θwallarray,curvarray=curvwallarray,Rn=Rn_boil);
 
     # Mapping


### PR DESCRIPTION
Originally, I used to get the midpoints of the ohp geometry to generate interpolaions. Recently I noticed that arccoord() is used, it used end points of the ohp to generate interpolations. Now I switch it back to arccoordmid() to serve my original purpose.

If not switching back, there is a possibility of crash (I sent you a test notebook to demonstrate that). And also, this is consistent with the way we extract 2D locations of the ohp points. (I believe ohp.x and ohp.y represents midpoints also rather than endpoints) This will also make my gravity calculation correct.

